### PR TITLE
Updating constructors with missing optional args

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ const queryExecutor = new ReadQueryExecutor(
 )
 ```
 
+#### Query Executor types
+
+There are 3 query executor classes, you should only need to construct the `ReadQueryExecutor` as above.
+
+-   `ReadQueryExecutor`: Entry point, represents a query executor not in a transaction
+-   `UnitOfWorkQueryExecutor`: Type used when function wants to execute a query inside a transaction
+-   `QueryExecutor`: Type when code does not care if the query is executed inside or outside a transaction
+
 ### Executing a query
 
 ```ts
@@ -69,6 +77,9 @@ const exampleQuery = queryExecutor.createQuery(async function exampleQuery<
     // It is the queries responsibility to ensure the type is correct
     return result
 })
+
+// Then execute the query
+const queryResult = await queryExecutor.execute(exampleQuery).withArgs({})
 ```
 
 ### Testing
@@ -76,7 +87,7 @@ const exampleQuery = queryExecutor.createQuery(async function exampleQuery<
 ```ts
 import { NoMatch, MockQueryExecutor } from 'node-query-executor'
 
-const queryExecutor = new MockQueryExecutor(tables)
+const queryExecutor = new MockQueryExecutor()
 
 const exampleQuery = queryExecutor.createQuery<{}, number>(async ({}) => {
     // real query here

--- a/src/mock-query-executor.ts
+++ b/src/mock-query-executor.ts
@@ -31,9 +31,9 @@ export class MockQueryExecutor<
     TTableNames extends string,
     Services extends {}
 > extends ReadQueryExecutor<TTableNames, Services> {
-    constructor(tableNames: TableNames<TTableNames>) {
+    constructor() {
         // The real query executor should not be called so this is fine
-        super(undefined as any, undefined as any, tableNames)
+        super(undefined as any, undefined as any, {} as any)
     }
     private mocks: Array<{
         query: Query<any, any, TTableNames, Services>

--- a/src/query-executor.ts
+++ b/src/query-executor.ts
@@ -6,7 +6,7 @@ export class QueryExecutor<
     Services extends object
 > {
     protected tables: Tables<TTableNames>
-    private wrap: QueryWrapper
+    protected wrap: QueryWrapper
 
     constructor(
         public kind: 'read-query-executor' | 'unit-of-work-query-executor',

--- a/src/read-query-executor.ts
+++ b/src/read-query-executor.ts
@@ -1,5 +1,5 @@
 import * as Knex from 'knex'
-import { TableNames } from '.'
+import { QueryWrapper, TableNames } from '.'
 import { QueryExecutor } from './query-executor'
 import { UnitOfWorkQueryExecutor } from './unit-of-work-query-executor'
 
@@ -12,9 +12,10 @@ export class ReadQueryExecutor<
     constructor(
         knex: Knex,
         services: Services,
-        tableNames: TableNames<TTableNames>
+        tableNames: TableNames<TTableNames>,
+        wrapQuery?: QueryWrapper
     ) {
-        super('read-query-executor', knex, services, tableNames)
+        super('read-query-executor', knex, services, tableNames, wrapQuery)
     }
 
     /**
@@ -32,7 +33,12 @@ export class ReadQueryExecutor<
             // knex is aware of promises, and will automatically commit
             // or reject based on this callback promise
             return work(
-                new UnitOfWorkQueryExecutor(trx, this.services, this.tableNames)
+                new UnitOfWorkQueryExecutor(
+                    trx,
+                    this.services,
+                    this.tableNames,
+                    this.wrap
+                )
             )
         })
     }

--- a/src/unit-of-work-query-executor.ts
+++ b/src/unit-of-work-query-executor.ts
@@ -1,5 +1,5 @@
 import * as Knex from 'knex'
-import { TableNames } from '.'
+import { QueryWrapper, TableNames } from '.'
 import { QueryExecutor } from './query-executor'
 
 export class UnitOfWorkQueryExecutor<
@@ -12,8 +12,15 @@ export class UnitOfWorkQueryExecutor<
     constructor(
         protected knex: Knex.Transaction,
         services: Services,
-        tableNames: TableNames<TTableNames>
+        tableNames: TableNames<TTableNames>,
+        wrapQuery?: QueryWrapper
     ) {
-        super('unit-of-work-query-executor', knex, services, tableNames)
+        super(
+            'unit-of-work-query-executor',
+            knex,
+            services,
+            tableNames,
+            wrapQuery
+        )
     }
 }


### PR DESCRIPTION
Added query wrapper to the read query executor and removed tableNames from the mock query executor