### PR TITLE
fix: Unit of work return type was Promise<any>

### DIFF
--- a/src/read-query-executor.ts
+++ b/src/read-query-executor.ts
@@ -28,7 +28,7 @@ export class ReadQueryExecutor<
         work: (
             executor: UnitOfWorkQueryExecutor<TTableNames, Services>
         ) => Promise<T>
-    ): PromiseLike<any> {
+    ): PromiseLike<T> {
         return this.knex.transaction(trx => {
             // knex is aware of promises, and will automatically commit
             // or reject based on this callback promise


### PR DESCRIPTION
It should be Promise<T> so the type returned from the unit of work callback function is returned from the `unitOfWork` function